### PR TITLE
new futur combinator suggestion #firstSuccessfulCompleteOf:.

### DIFF
--- a/TaskIt-Tests/TKTFutureTest.class.st
+++ b/TaskIt-Tests/TKTFutureTest.class.st
@@ -337,6 +337,61 @@ TKTFutureTest >> testFutureFirstCompleteOfSuccessIfSecondSuccessFaster [
 ]
 
 { #category : #'tests-combinators' }
+TKTFutureTest >> testFutureFirstSuccessfulCompleteOfBothFails [
+	| future got secondFuture error |
+	future := TKTFuture new.
+	secondFuture := TKTFuture new.
+	(future firstSuccessfulCompleteOf: secondFuture)
+		onFailureDo:  [ :v | got := v ].
+	error := Error new.
+	[ error signal ]
+		on: Error
+		do: [ :e | 
+			future deployFailure: e.
+			secondFuture deployFailure: e ].
+	50 milliSecond wait.
+	self assert: got equals: error
+]
+
+{ #category : #'tests-combinators' }
+TKTFutureTest >> testFutureFirstSuccessfulCompleteOfSecondIsSuccessful [
+
+	| future got secondFuture error |
+	future := TKTFuture new.
+	secondFuture := TKTFuture new.
+	
+	(future firstSuccessfulCompleteOf: secondFuture) onSuccessDo: [ :v | got := v ].
+
+	secondFuture deploySuccess: 1.
+	error := Error new.
+	[ error signal ]
+		on: Error
+		do: [ :e | future deployFailure: e ].
+	50 milliSecond wait.
+
+	self assert: got equals: 1
+]
+
+{ #category : #'tests-combinators' }
+TKTFutureTest >> testFutureFirstSuccessfulCompleteOfSecondIsSuccessfulFirstFailsFirst [
+
+	| future got secondFuture error |
+	future := TKTFuture new.
+	secondFuture := TKTFuture new.
+	
+	(future firstSuccessfulCompleteOf: secondFuture) onSuccessDo: [ :v | got := v ].
+
+	error := Error new.
+	[ error signal ]
+		on: Error
+		do: [ :e | future deployFailure: e ].
+	secondFuture deploySuccess: 1.
+	50 milliSecond wait.
+
+	self assert: got equals: 1
+]
+
+{ #category : #'tests-combinators' }
 TKTFutureTest >> testFutureFlatCollectFailsOnFailingMapFunction [
 
 	| future got error |

--- a/TaskIt/TKTFuture.class.st
+++ b/TaskIt/TKTFuture.class.st
@@ -273,6 +273,40 @@ TKTFuture >> firstCompleteOf: anotherFuture [
 	^ future
 ]
 
+{ #category : #callback }
+TKTFuture >> firstSuccessfulCompleteOf: anotherFuture [
+	| finished returnFuture oneFinished |
+	oneFinished := false.
+	finished := false.
+	returnFuture := TKTFuture new.
+	returnFuture runner: runner.
+	self
+		onSuccessDo: [ :v | 
+			finished
+				ifFalse: [ finished := true.
+					returnFuture deploySuccess: v ] ].
+	self
+		onFailureDo: [ :v | 
+			finished
+				ifFalse: [ oneFinished
+						ifTrue: [ finished := true.
+							returnFuture deployFailure: v freeze ]
+						ifFalse: [ oneFinished := true ] ] ].
+	anotherFuture
+		onSuccessDo: [ :v | 
+			finished
+				ifFalse: [ finished := true.
+					returnFuture deploySuccess: v ] ].
+	anotherFuture
+		onFailureDo: [ :v | 
+			finished
+				ifFalse: [ oneFinished
+						ifTrue: [ finished := true.
+							returnFuture deployFailure: v freeze ]
+						ifFalse: [ oneFinished := true ] ]  ].
+	^ returnFuture
+]
+
 { #category : #combinators }
 TKTFuture >> flatCollect: aBlockClosure [ 
 	


### PR DESCRIPTION
Hello guys, 
Could you please consider this contribution ? or just discuss about my usecase...

My usecase:
- I have to decrypt some data that might have been encrypted using different (known) private keys.
- I have up to 100 possible keys.
- The decryption service is a microservice somewhere.
- I want to send all decryption requests at the same time and get the first successful one. 

I think this #firstSucccessfulCompleteOf: is a cool addiction to taskIt futur combinators and could come handy in other usecases.

Although the error handling I implemented is terrible... 

Please let me know what you think about it.

regards 
max