### PR TITLE
For Pharo 9, don't include TaskitDebugger in default group

### DIFF
--- a/BaselineOfTaskIt/BaselineOfTaskIt.class.st
+++ b/BaselineOfTaskIt/BaselineOfTaskIt.class.st
@@ -190,7 +190,7 @@ BaselineOfTaskIt >> baselineForPharo9: spec [
 	self baselineForCommon: spec.
 
 	"Override group without the TaskItDebugger package (and tests)."
-	spec group: 'default' with: #(
+	spec group: 'default' overrides: #(
 		'core' 
 		'TaskItProcesses' 
 		'TaskItRetry' 

--- a/BaselineOfTaskIt/BaselineOfTaskIt.class.st
+++ b/BaselineOfTaskIt/BaselineOfTaskIt.class.st
@@ -187,5 +187,15 @@ BaselineOfTaskIt >> baselineForPharo8: spec [
 BaselineOfTaskIt >> baselineForPharo9: spec [
 
 	spec package: #TaskIt.
-	self baselineForCommon: spec
+	self baselineForCommon: spec.
+
+	"Override group without the TaskItDebugger package (and tests)."
+	spec group: 'default' with: #(
+		'core' 
+		'TaskItProcesses' 
+		'TaskItRetry' 
+		'TaskIt-Tests' 
+		'TaskItRetry-Tests' 
+		'TaskItProcesses-Tests').
+
 ]


### PR DESCRIPTION


Fixes #94 

See issue for more details 