### PR TITLE
Changes from Pharo 9

### DIFF
--- a/TaskIt-Tests/TKTServiceManagerTest.class.st
+++ b/TaskIt-Tests/TKTServiceManagerTest.class.st
@@ -17,7 +17,7 @@ TKTServiceManagerTest >> testCannotStartTwoServicesWithSameName [
 	newService step: [ 100 milliSeconds wait ].
 	self should: [ newService start ] raise: Error ]
 		ensure: [ service stop.
-			[ newService stop ] ifError: [  ].
+			[ newService stop ] onErrorDo: [  ].
 			200 milliSeconds wait ]
 ]
 

--- a/TaskIt-Tests/TKTServiceManagerTest.class.st
+++ b/TaskIt-Tests/TKTServiceManagerTest.class.st
@@ -17,7 +17,7 @@ TKTServiceManagerTest >> testCannotStartTwoServicesWithSameName [
 	newService step: [ 100 milliSeconds wait ].
 	self should: [ newService start ] raise: Error ]
 		ensure: [ service stop.
-			[ newService stop ] onErrorDo: [  ].
+			[ newService stop ] on: Error do: [ "ignore" ].
 			200 milliSeconds wait ]
 ]
 

--- a/TaskIt-Tests/TKTTestCase.class.st
+++ b/TaskIt-Tests/TKTTestCase.class.st
@@ -12,14 +12,14 @@ TKTTestCase >> garbageCollectAndWait [
 	5
 		timesRepeat: [ Smalltalk garbageCollect.
 			100 milliSeconds wait ].
-	1 second wait.
+"	1 second wait.
 	5
 		timesRepeat: [ Smalltalk garbageCollect.
 			100 milliSeconds wait ].
 	1 second wait.
 	5
 		timesRepeat: [ Smalltalk garbageCollect.
-			100 milliSeconds wait ]
+			100 milliSeconds wait ]"
 ]
 
 { #category : #running }

--- a/TaskIt-Tests/TKTTestCase.class.st
+++ b/TaskIt-Tests/TKTTestCase.class.st
@@ -9,17 +9,9 @@ Class {
 
 { #category : #running }
 TKTTestCase >> garbageCollectAndWait [
-	5
-		timesRepeat: [ Smalltalk garbageCollect.
-			100 milliSeconds wait ].
-"	1 second wait.
-	5
-		timesRepeat: [ Smalltalk garbageCollect.
-			100 milliSeconds wait ].
-	1 second wait.
-	5
-		timesRepeat: [ Smalltalk garbageCollect.
-			100 milliSeconds wait ]"
+	5 timesRepeat: [
+		Smalltalk garbageCollect.
+		100 milliSeconds wait ].
 ]
 
 { #category : #running }

--- a/TaskIt/TKTAbstractExecutor.class.st
+++ b/TaskIt/TKTAbstractExecutor.class.st
@@ -15,6 +15,12 @@ Class {
 	#category : #'TaskIt-Kernel'
 }
 
+{ #category : #testing }
+TKTAbstractExecutor class >> isAbstract [
+
+	^self == TKTAbstractExecutor 
+]
+
 { #category : #accessing }
 TKTAbstractExecutor >> exceptionHandler [
 	^ exceptionHandler
@@ -33,36 +39,36 @@ TKTAbstractExecutor >> initialize [
 	exceptionHandler := TKTConfiguration errorHandler
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 TKTAbstractExecutor >> isBusy [
 
 	^ busy
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 TKTAbstractExecutor >> isFree [
 
 	^ busy not
 ]
 
-{ #category : #accessing }
+{ #category : #'as yet unclassified' }
 TKTAbstractExecutor >> noteBusy [
 
 	busy := true
 ]
 
-{ #category : #accessing }
+{ #category : #'as yet unclassified' }
 TKTAbstractExecutor >> noteFree [
 
 	busy := false
 ]
 
-{ #category : #polimorfism }
+{ #category : #polymorphism }
 TKTAbstractExecutor >> start [
  " nothing to do "
 ]
 
-{ #category : #polimorfsms }
+{ #category : #polymorphism }
 TKTAbstractExecutor >> stop [
 
 ]

--- a/TaskIt/TKTLocalProcessTaskRunner.class.st
+++ b/TaskIt/TKTLocalProcessTaskRunner.class.st
@@ -25,23 +25,20 @@ While this runner may seem a bit naive, it may also come in handy to control and
 Class {
 	#name : #TKTLocalProcessTaskRunner,
 	#superclass : #TKTRunner,
-	#instVars : [
-		'process'
-	],
 	#category : #'TaskIt-Kernel'
 }
 
-{ #category : #schedulling }
+{ #category : #scheduling }
 TKTLocalProcessTaskRunner >> isLocalThreadRunner [
 	^ true
 ]
 
-{ #category : #schedulling }
+{ #category : #scheduling }
 TKTLocalProcessTaskRunner >> scheduleTaskExecution: aTaskExecution [
 	self executeTask: aTaskExecution
 ]
 
-{ #category : #polimorfism }
+{ #category : #polymorphism }
 TKTLocalProcessTaskRunner >> start [
 
 ]

--- a/TaskIt/TKTNewProcessTaskRunner.class.st
+++ b/TaskIt/TKTNewProcessTaskRunner.class.st
@@ -51,7 +51,7 @@ Class {
 	#category : #'TaskIt-Kernel'
 }
 
-{ #category : #schedulling }
+{ #category : #scheduling }
 TKTNewProcessTaskRunner >> scheduleTaskExecution: aTaskExecution [
 	TKTConfiguration processProvider
 		createProcessDoing:

--- a/TaskIt/TKTPromise.class.st
+++ b/TaskIt/TKTPromise.class.st
@@ -6,12 +6,5 @@ A promise is registered and kept up to the end of the computation and applicatio
 Class {
 	#name : #TKTPromise,
 	#superclass : #Object,
-	#instVars : [
-		'result',
-		'valueSemaphore',
-		'resultCallbacks',
-		'exceptionCallbacks',
-		'runner'
-	],
 	#category : #'TaskIt-Futures'
 }

--- a/TaskIt/TKTRunner.class.st
+++ b/TaskIt/TKTRunner.class.st
@@ -45,3 +45,9 @@ Class {
 	#classTraits : 'TTaskScheduler classTrait',
 	#category : #'TaskIt-Kernel'
 }
+
+{ #category : #testing }
+TKTRunner class >> isAbstract [
+
+	^self == TKTRunner 
+]

--- a/TaskIt/TKTTaskExecution.class.st
+++ b/TaskIt/TKTTaskExecution.class.st
@@ -8,8 +8,6 @@ Class {
 		'runner',
 		'task',
 		'executionProcess',
-		'isRunning',
-		'cancelled',
 		'state'
 	],
 	#category : #'TaskIt-Kernel'

--- a/TaskIt/TKTUIProcessTaskRunner.class.st
+++ b/TaskIt/TKTUIProcessTaskRunner.class.st
@@ -1,23 +1,20 @@
 Class {
 	#name : #TKTUIProcessTaskRunner,
 	#superclass : #TKTRunner,
-	#instVars : [
-		'process'
-	],
 	#category : #'TaskIt-Kernel'
 }
 
-{ #category : #schedulling }
+{ #category : #scheduling }
 TKTUIProcessTaskRunner >> isUIRunner [
 	^ true 
 ]
 
-{ #category : #schedulling }
+{ #category : #scheduling }
 TKTUIProcessTaskRunner >> scheduleTaskExecution: aTaskExecution [
 	WorldState addDeferredUIMessage: [ self executeTask: aTaskExecution ]
 ]
 
-{ #category : #polimorfsms }
+{ #category : #polymorphism }
 TKTUIProcessTaskRunner >> start [
 
 ]

--- a/TaskIt/TKTWorkerPool.class.st
+++ b/TaskIt/TKTWorkerPool.class.st
@@ -32,7 +32,6 @@ Class {
 	#classTraits : 'TTaskScheduler classTrait',
 	#instVars : [
 		'poolMaxSize',
-		'busyWorkers',
 		'freeWorkers',
 		'poolWorker',
 		'workers',

--- a/TaskIt/TTaskExecutor.trait.st
+++ b/TaskIt/TTaskExecutor.trait.st
@@ -27,18 +27,18 @@ TTaskExecutor >> executeTask: aTaskExecution [
 		do: [ :error | self exceptionHandler handleException: error ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 TTaskExecutor >> isDebuggingCompatible [
 	^ false
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 TTaskExecutor >> noteBusy [
 
 	self shouldBeImplemented
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 TTaskExecutor >> noteFree [
 
 	self shouldBeImplemented


### PR DESCRIPTION
Build information: Pharo-9.0.0+build.1236.sha.5c9b8c3ad1eb1041eff2f97b7f5bf3dd36c039ab (64 Bit)

Changes:
- Recategorized methods
- Clean up of unused instvars
- Mark class as abstract
- Rename deprecated ifError: in testCannotStartTwoServicesWithSameName
- Partially comment code of TKTTestCase>>garbageCollectAndWait